### PR TITLE
Add Jenkinsfile (npm audit high, docker build/push) and app Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:16-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --only=production
+COPY . .
+EXPOSE 8081
+CMD ["node", "app.js"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
     buildDiscarder(logRotator(numToKeepStr: '15', artifactNumToKeepStr: '10'))
   }
   environment {
-    IMAGE_NAME = "<your-dockerhub-username>/eb-express"
+    IMAGE_NAME = "<PUT_YOUR_DOCKERHUB_USERNAME_HERE>/eb-express"
     IMAGE_TAG  = "${env.BRANCH_NAME}-${env.BUILD_NUMBER}"
   }
   stages {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,52 @@
+pipeline {
+  agent any
+  options {
+    timestamps()
+    buildDiscarder(logRotator(numToKeepStr: '15', artifactNumToKeepStr: '10'))
+  }
+  environment {
+    IMAGE_NAME = "<your-dockerhub-username>/eb-express"
+    IMAGE_TAG  = "${env.BRANCH_NAME}-${env.BUILD_NUMBER}"
+  }
+  stages {
+    stage('Checkout') {
+      steps { checkout scm }
+    }
+
+    stage('Install & Test (Node 16)') {
+      agent { docker { image 'node:16-alpine' args '-v $HOME/.npm:/root/.npm' } }
+      steps {
+        sh 'node -v && npm -v'
+        sh 'npm ci'
+        sh 'npm test || echo "no tests"'
+      }
+    }
+
+    stage('Dependency Scan (fail on HIGH)') {
+      agent { docker { image 'node:16-alpine' } }
+      steps {
+        sh 'npm ci --prefer-offline --no-audit'
+        sh 'npm audit --audit-level=high'
+      }
+    }
+
+    stage('Build Image') {
+      steps {
+        sh 'docker build -t $IMAGE_NAME:$IMAGE_TAG .'
+      }
+    }
+
+    stage('Login & Push') {
+      steps {
+        withCredentials([usernamePassword(credentialsId: 'dockerhub-creds', usernameVariable: 'DOCKER_USER', passwordVariable: 'DOCKER_PASS')]) {
+          sh 'echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin'
+        }
+        sh 'docker push $IMAGE_NAME:$IMAGE_TAG'
+      }
+    }
+  }
+  post {
+    success { echo "Pushed $IMAGE_NAME:$IMAGE_TAG" }
+    always  { archiveArtifacts artifacts: '**/npm-debug.log', allowEmptyArchive: true }
+  }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
     buildDiscarder(logRotator(numToKeepStr: '15', artifactNumToKeepStr: '10'))
   }
   environment {
-    IMAGE_NAME = "22471264/eb-express"
+    IMAGE_NAME = "22471264/eb-express" 
     IMAGE_TAG  = "${env.BRANCH_NAME}-${env.BUILD_NUMBER}"
   }
   stages {
@@ -14,7 +14,12 @@ pipeline {
     }
 
     stage('Install & Test (Node 16)') {
-      agent { docker { image 'node:16-alpine' args '-v $HOME/.npm:/root/.npm' } }
+      agent {
+        docker {
+          image 'node:16-alpine'
+          args '-v $HOME/.npm:/root/.npm'
+        }
+      }
       steps {
         sh 'node -v && npm -v'
         sh 'npm ci'
@@ -23,7 +28,11 @@ pipeline {
     }
 
     stage('Dependency Scan (fail on HIGH)') {
-      agent { docker { image 'node:16-alpine' } }
+      agent {
+        docker {
+          image 'node:16-alpine'
+        }
+      }
       steps {
         sh 'npm ci --prefer-offline --no-audit'
         sh 'npm audit --audit-level=high'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
     buildDiscarder(logRotator(numToKeepStr: '15', artifactNumToKeepStr: '10'))
   }
   environment {
-    IMAGE_NAME = "<PUT_YOUR_DOCKERHUB_USERNAME_HERE>/eb-express"
+    IMAGE_NAME = "22471264/eb-express"
     IMAGE_TAG  = "${env.BRANCH_NAME}-${env.BUILD_NUMBER}"
   }
   stages {


### PR DESCRIPTION
This pull request adds:
- Jenkinsfile defining the CI/CD pipeline with checkout, testing, npm audit, Docker build, and push stages.
- Dockerfile for containerizing the Node.js application.
These changes support Task 3 of the assessment.
